### PR TITLE
ENTESB-11007: Fixed Jackson-databind CVEs in camel-k-runtime

### DIFF
--- a/camel-k-maven-plugin/pom.xml
+++ b/camel-k-maven-plugin/pom.xml
@@ -99,7 +99,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${jackson.version}</version>
+      <version>${jackson.databind.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/camel-k-runtime-yaml/pom.xml
+++ b/camel-k-runtime-yaml/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson.databind.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>

--- a/camel-knative/pom.xml
+++ b/camel-knative/pom.xml
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson.databind.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,8 @@
         <kotlin.version>1.3.31</kotlin.version>
         <snakeyaml.version>1.24</snakeyaml.version>
         <spock.version>1.3-groovy-2.5</spock.version>
-        <jackson.version>2.9.8</jackson.version>
+        <jackson.version>2.9.10</jackson.version>
+        <jackson.databind.version>2.9.10.1</jackson.databind.version>
         <immutables.version>2.7.5</immutables.version>
         <semver4j.version>2.2.0</semver4j.version>
         <undertow.version>1.4.26.Final</undertow.version>


### PR DESCRIPTION
I also plan to port this one to 0.3.x.redhat-7-x for Fuse 7.7.