### PR TITLE
Use org.testcontainers:testcontainers rather than camel-quarkus-integration-testcontainers-support

### DIFF
--- a/itests/camel-k-itests-kamelet-reify/pom.xml
+++ b/itests/camel-k-itests-kamelet-reify/pom.xml
@@ -98,9 +98,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.camel.quarkus</groupId>
-            <artifactId>camel-quarkus-integration-testcontainers-support</artifactId>
-            <version>${camel-quarkus-version}</version>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Use org.testcontainers:testcontainers rather than camel-quarkus-integration-testcontainers-support which is not deployed in camel-quarkus 1.8.1 prod branch