### PR TITLE
[Backport] fix: use the quarkus catalog instead of the vanilla one

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -832,7 +832,7 @@
                         <dependencies>
                             <dependency>
                                 <groupId>org.apache.camel</groupId>
-                                <artifactId>camel-catalog</artifactId>
+                                <artifactId>camel-quarkus-catalog</artifactId>
                                 <version>${camel-version}</version>
                             </dependency>
                         </dependencies>


### PR DESCRIPTION
@lburgazzoli can you please confirm if we can backport in this release? Building with vanilla catalog is no longer giving problems, so, I am not sure if we want to backport in next release to be on a safe spot.