### PR TITLE
ENTESB-17631 Add a quarkus-logging-json dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <!-- quarkus -->
         <camel-quarkus-version>2.2.0-SNAPSHOT</camel-quarkus-version>
         <graalvm-version>21.2.0</graalvm-version>
-        <quarkus-version>2.2.2.Final-redhat-00001</quarkus-version>
+        <quarkus-version>2.2.3.Final-redhat-00008</quarkus-version>
 
         <!-- camel-k -->
         <groovy-version>3.0.8</groovy-version>
@@ -764,6 +764,12 @@
                 <artifactId>hamcrest-core</artifactId>
                 <version>${hamcrest-version}</version>
             </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-logging-json</artifactId>
+                <version>${quarkus-version}</version>
+            </dependency>
+
 
             <!-- maven -->
             <dependency>

--- a/support/camel-k-maven-plugin/pom.xml
+++ b/support/camel-k-maven-plugin/pom.xml
@@ -141,6 +141,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-logging-json</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
https://issues.redhat.com/browse/ENTESB-17631

Changed quarkus-version because camel-k-maven-plugin generate-catalog/verify.groovy was failing.   I think it's failing because the quarkus version pulled in by camel-quarkus is newer, updating the quarkus-version fixed that issue.