### PR TITLE
chore(deps): camel-openapi-rest-dsl-generator community dependency

### DIFF
--- a/itests/camel-k-itests-loader-groovy/pom.xml
+++ b/itests/camel-k-itests-loader-groovy/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-groovy-dsl</artifactId>
-            <version>${camel-version}</version>
+            <version>${camel-community.version}</version>
             <type>pom</type>
             <scope>test</scope>
             <exclusions>

--- a/itests/camel-k-itests-runtime/pom.xml
+++ b/itests/camel-k-itests-runtime/pom.xml
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-groovy-dsl</artifactId>
-            <version>${camel-version}</version>
+            <version>${camel-community.version}</version>
             <type>pom</type>
             <scope>test</scope>
             <exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
         <maven.compiler.target>11</maven.compiler.target>
 
         <camel-version>3.11.1.fuse-800003-redhat-00002</camel-version>
+        <camel-community.version>3.11.1</camel-community.version>
 
         <!-- quarkus -->
         <camel-quarkus-version>2.2.0-SNAPSHOT</camel-quarkus-version>

--- a/support/camel-k-maven-plugin/pom.xml
+++ b/support/camel-k-maven-plugin/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-openapi-rest-dsl-generator</artifactId>
-            <version>${camel-version}</version>
+            <version>${camel-community.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>


### PR DESCRIPTION
Pending the discussion if it's a change worth to it. Would it be the right way to include a community dependency if we go that path?

cc @lburgazzoli @ppalaga @balejosg @cunningt 

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
