### PR TITLE
Use a different property version for quarkus-bootstrap-maven-plugin

### DIFF
--- a/camel-k-cloudevents/runtime/pom.xml
+++ b/camel-k-cloudevents/runtime/pom.xml
@@ -43,7 +43,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
-                <version>${quarkus-version}</version>
+                <version>${quarkus-bootstrap-maven-plugin-version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/camel-k-core/runtime/pom.xml
+++ b/camel-k-core/runtime/pom.xml
@@ -61,7 +61,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
-                <version>${quarkus-version}</version>
+                <version>${quarkus-bootstrap-maven-plugin-version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/camel-k-cron/runtime/pom.xml
+++ b/camel-k-cron/runtime/pom.xml
@@ -47,7 +47,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
-                <version>${quarkus-version}</version>
+                <version>${quarkus-bootstrap-maven-plugin-version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/camel-k-knative/consumer/runtime/pom.xml
+++ b/camel-k-knative/consumer/runtime/pom.xml
@@ -59,7 +59,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
-                <version>${quarkus-version}</version>
+                <version>${quarkus-bootstrap-maven-plugin-version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/camel-k-knative/producer/runtime/pom.xml
+++ b/camel-k-knative/producer/runtime/pom.xml
@@ -59,7 +59,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
-                <version>${quarkus-version}</version>
+                <version>${quarkus-bootstrap-maven-plugin-version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/camel-k-knative/runtime/pom.xml
+++ b/camel-k-knative/runtime/pom.xml
@@ -60,7 +60,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
-                <version>${quarkus-version}</version>
+                <version>${quarkus-bootstrap-maven-plugin-version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/camel-k-loader-jsh/runtime/pom.xml
+++ b/camel-k-loader-jsh/runtime/pom.xml
@@ -43,7 +43,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
-                <version>${quarkus-version}</version>
+                <version>${quarkus-bootstrap-maven-plugin-version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/camel-k-master/runtime/pom.xml
+++ b/camel-k-master/runtime/pom.xml
@@ -51,7 +51,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
-                <version>${quarkus-version}</version>
+                <version>${quarkus-bootstrap-maven-plugin-version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/camel-k-runtime/runtime/pom.xml
+++ b/camel-k-runtime/runtime/pom.xml
@@ -47,7 +47,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
-                <version>${quarkus-version}</version>
+                <version>${quarkus-bootstrap-maven-plugin-version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/camel-k-webhook/runtime/pom.xml
+++ b/camel-k-webhook/runtime/pom.xml
@@ -47,7 +47,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
-                <version>${quarkus-version}</version>
+                <version>${quarkus-bootstrap-maven-plugin-version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/examples/cron/pom.xml
+++ b/examples/cron/pom.xml
@@ -66,7 +66,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
-                <version>${quarkus-version}</version>
+                <version>${quarkus-bootstrap-maven-plugin-version}</version>
             </plugin>
             <plugin>
                 <groupId>io.quarkus</groupId>

--- a/examples/groovy/pom.xml
+++ b/examples/groovy/pom.xml
@@ -58,7 +58,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
-                <version>${quarkus-version}</version>
+                <version>${quarkus-bootstrap-maven-plugin-version}</version>
             </plugin>
             <plugin>
                 <groupId>io.quarkus</groupId>

--- a/examples/java/pom.xml
+++ b/examples/java/pom.xml
@@ -58,7 +58,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
-                <version>${quarkus-version}</version>
+                <version>${quarkus-bootstrap-maven-plugin-version}</version>
             </plugin>
             <plugin>
                 <groupId>io.quarkus</groupId>

--- a/examples/js/pom.xml
+++ b/examples/js/pom.xml
@@ -58,7 +58,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
-                <version>${quarkus-version}</version>
+                <version>${quarkus-bootstrap-maven-plugin-version}</version>
             </plugin>
             <plugin>
                 <groupId>io.quarkus</groupId>

--- a/examples/kafka-source-s3/pom.xml
+++ b/examples/kafka-source-s3/pom.xml
@@ -58,7 +58,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
-                <version>${quarkus-version}</version>
+                <version>${quarkus-bootstrap-maven-plugin-version}</version>
             </plugin>
             <plugin>
                 <groupId>io.quarkus</groupId>

--- a/examples/kamelets-discovery/pom.xml
+++ b/examples/kamelets-discovery/pom.xml
@@ -61,7 +61,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
-                <version>${quarkus-version}</version>
+                <version>${quarkus-bootstrap-maven-plugin-version}</version>
             </plugin>
             <plugin>
                 <groupId>io.quarkus</groupId>

--- a/examples/kamelets/pom.xml
+++ b/examples/kamelets/pom.xml
@@ -61,7 +61,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
-                <version>${quarkus-version}</version>
+                <version>${quarkus-bootstrap-maven-plugin-version}</version>
             </plugin>
             <plugin>
                 <groupId>io.quarkus</groupId>

--- a/examples/knative/pom.xml
+++ b/examples/knative/pom.xml
@@ -65,7 +65,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
-                <version>${quarkus-version}</version>
+                <version>${quarkus-bootstrap-maven-plugin-version}</version>
             </plugin>
             <plugin>
                 <groupId>io.quarkus</groupId>

--- a/examples/kotlin/pom.xml
+++ b/examples/kotlin/pom.xml
@@ -57,7 +57,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
-                <version>${quarkus-version}</version>
+                <version>${quarkus-bootstrap-maven-plugin-version}</version>
             </plugin>
             <plugin>
                 <groupId>io.quarkus</groupId>

--- a/examples/xml/pom.xml
+++ b/examples/xml/pom.xml
@@ -57,7 +57,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
-                <version>${quarkus-version}</version>
+                <version>${quarkus-bootstrap-maven-plugin-version}</version>
             </plugin>
             <plugin>
                 <groupId>io.quarkus</groupId>

--- a/examples/yaml/pom.xml
+++ b/examples/yaml/pom.xml
@@ -61,7 +61,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
-                <version>${quarkus-version}</version>
+                <version>${quarkus-bootstrap-maven-plugin-version}</version>
             </plugin>
             <plugin>
                 <groupId>io.quarkus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
         <!-- quarkus -->
         <camel-quarkus-version>2.7.1</camel-quarkus-version>
         <quarkus-version>2.7.5.Final</quarkus-version>
+        <quarkus-bootstrap-maven-plugin-version>2.7.5.Final</quarkus-bootstrap-maven-plugin-version>
         <quarkus-native-builder-image>registry.redhat.io/quarkus/mandrel-21-rhel8:21.3</quarkus-native-builder-image>
 
         <!-- camel-k -->


### PR DESCRIPTION
Use a different property version for quarkus-bootstrap-maven-plugin, which is not included in the 2.7.5.SP1-redhat-00001 platform build






<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
