### PR TITLE
ENTESB-19671 Set jolokia dependency in camel-k-runtime-bom

### DIFF
--- a/support/camel-k-runtime-bom/pom.xml
+++ b/support/camel-k-runtime-bom/pom.xml
@@ -35,6 +35,7 @@
         <quarkus-platform-version>2.7.6.Final</quarkus-platform-version>
         <!-- reproduceable builds: https://maven.apache.org/guides/mini/guide-reproducible-builds.html -->
         <project.build.outputTimestamp>1644316906</project.build.outputTimestamp>
+        <jolokia-version>1.7.1</jolokia-version>
 
         <maven-enforcer-plugin-version>3.0.0</maven-enforcer-plugin-version>
         <maven-version>3.6.2</maven-version>
@@ -234,6 +235,11 @@
                 <groupId>org.apache.camel.k</groupId>
                 <artifactId>camel-k-maven-plugin</artifactId>
                 <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jolokia</groupId>
+                <artifactId>jolokia-jvm</artifactId>
+                <version>${jolokia-version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
ENTESB-19671 The supported trait jolokia doesn't use productised artifacts
https://issues.redhat.com/browse/ENTESB-19671

**Release Note**
```release-note
NONE
```
