### PR TITLE
Experiment setting a property for quarkus-camel-bom artifact

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,10 @@
         <camel-quarkus-version>2.13.1</camel-quarkus-version>
         <quarkus-version>2.13.3.Final</quarkus-version>
         <quarkus-platform-version>2.13.4.Final</quarkus-platform-version>
+        <!-- Having quarkus-camel-platform-version property allows PNC to properly align versions to the latest redhat build,
+             event if it is the same as of quarkus-platform-version, the redhat build may eventually be different
+        -->
+        <quarkus-camel-platform-version>2.13.4.Final</quarkus-camel-platform-version>
         <quarkus-native-builder-image>registry.redhat.io/quarkus/mandrel-21-rhel8:21.3</quarkus-native-builder-image>
 
         <!-- camel-k-runtime specific -->
@@ -132,7 +136,7 @@
                           <rules>
                             <requireMavenVersion>
                               <version>${maven-version}</version>
-                            </requireMavenVersion>                           
+                            </requireMavenVersion>
                           </rules>
                         </configuration>
                       </execution>
@@ -310,7 +314,7 @@
                                 <property>camel-version</property>
                                 <regex>${project.parent.version}</regex>
                                 <regexMessage>Camel version must be equals to camel-dependency parent pom version (${project.parent.version})!</regexMessage>
-                            </requireProperty>                            
+                            </requireProperty>
                         </rules>
                         <fail>true</fail>
                     </configuration>
@@ -389,7 +393,7 @@
     </modules>
 
     <dependencyManagement>
-        <dependencies>     
+        <dependencies>
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-bom</artifactId>
@@ -407,7 +411,7 @@
             <dependency>
                 <groupId>com.redhat.quarkus.platform</groupId>
                 <artifactId>quarkus-camel-bom</artifactId>
-                <version>${quarkus-platform-version}</version>
+                <version>${quarkus-camel-platform-version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
As PNC build fails when there could be two different redhat builds of quarkus platform

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
