### PR TITLE
Experiment setting a property for quarkus-camel-bom artifact

### DIFF
--- a/support/camel-k-runtime-bom/pom.xml
+++ b/support/camel-k-runtime-bom/pom.xml
@@ -35,6 +35,10 @@
     <maven-enforcer-plugin-version>3.1.0</maven-enforcer-plugin-version>
     <maven-version>3.6.3</maven-version>
     <quarkus-platform-version>2.13.4.Final</quarkus-platform-version>
+    <!-- Having quarkus-camel-platform-version property allows PNC to properly align versions to the latest redhat build,
+         event if it is the same as of quarkus-platform-version, the redhat build may eventually be different
+    -->
+    <quarkus-camel-platform-version>2.13.4.Final</quarkus-camel-platform-version>      
   </properties>
   <developers>
     <developer>
@@ -95,7 +99,7 @@
       <dependency>
         <groupId>com.redhat.quarkus.platform</groupId>
         <artifactId>quarkus-camel-bom</artifactId>
-        <version>${quarkus-platform-version}</version>
+        <version>${quarkus-camel-platform-version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
As PNC build fails when there could be two different redhat builds of quarkus platform

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
