### PR TITLE
Revert: adding a new quarkus-camel-platform-version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,10 +40,6 @@
         <camel-quarkus-version>2.13.1</camel-quarkus-version>
         <quarkus-version>2.13.3.Final</quarkus-version>
         <quarkus-platform-version>2.13.4.Final</quarkus-platform-version>
-        <!-- Having quarkus-camel-platform-version property allows PNC to properly align versions to the latest redhat build,
-             event if it is the same as of quarkus-platform-version, the redhat build may eventually be different
-        -->
-        <quarkus-camel-platform-version>2.13.4.Final</quarkus-camel-platform-version>
         <quarkus-native-builder-image>registry.redhat.io/quarkus/mandrel-21-rhel8:21.3</quarkus-native-builder-image>
 
         <!-- camel-k-runtime specific -->
@@ -136,7 +132,7 @@
                           <rules>
                             <requireMavenVersion>
                               <version>${maven-version}</version>
-                            </requireMavenVersion>
+                            </requireMavenVersion>                           
                           </rules>
                         </configuration>
                       </execution>
@@ -314,7 +310,7 @@
                                 <property>camel-version</property>
                                 <regex>${project.parent.version}</regex>
                                 <regexMessage>Camel version must be equals to camel-dependency parent pom version (${project.parent.version})!</regexMessage>
-                            </requireProperty>
+                            </requireProperty>                            
                         </rules>
                         <fail>true</fail>
                     </configuration>
@@ -393,7 +389,7 @@
     </modules>
 
     <dependencyManagement>
-        <dependencies>
+        <dependencies>     
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-bom</artifactId>
@@ -411,7 +407,7 @@
             <dependency>
                 <groupId>com.redhat.quarkus.platform</groupId>
                 <artifactId>quarkus-camel-bom</artifactId>
-                <version>${quarkus-camel-platform-version}</version>
+                <version>${quarkus-platform-version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/support/camel-k-runtime-bom/pom.xml
+++ b/support/camel-k-runtime-bom/pom.xml
@@ -35,10 +35,6 @@
     <maven-enforcer-plugin-version>3.1.0</maven-enforcer-plugin-version>
     <maven-version>3.6.3</maven-version>
     <quarkus-platform-version>2.13.4.Final</quarkus-platform-version>
-    <!-- Having quarkus-camel-platform-version property allows PNC to properly align versions to the latest redhat build,
-         event if it is the same as of quarkus-platform-version, the redhat build may eventually be different
-    -->
-    <quarkus-camel-platform-version>2.13.4.Final</quarkus-camel-platform-version>      
   </properties>
   <developers>
     <developer>
@@ -99,7 +95,7 @@
       <dependency>
         <groupId>com.redhat.quarkus.platform</groupId>
         <artifactId>quarkus-camel-bom</artifactId>
-        <version>${quarkus-camel-platform-version}</version>
+        <version>${quarkus-platform-version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
The experiment of having a different property for `quarkus-camel-platform-version` didn't work as quarkus-maven-plugin failed with
```
[ERROR] Failed to execute goal io.quarkus:quarkus-maven-plugin:2.13.3.Final-redhat-00003:build (default) on project camel-k-itests-core: Failed to build quarkus application: io.quarkus.builder.BuildException: Build failure: Build failed due to errors
[ERROR]     [error]: Build step io.quarkus.deployment.steps.CurateOutcomeBuildStep#curateOutcome threw an exception: java.lang.RuntimeException: Some of the imported Quarkus platform BOMs belong to different platform releases. To properly align the platform BOM imports, please, consider one of the following combinations:
[ERROR] For platform com.redhat.quarkus.platform:
```

**Release Note**
```release-note
NONE
```
