### PR TITLE
Replaces the quarkus-camel-bom with the camel-quarkus-bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -405,9 +405,9 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>com.redhat.quarkus.platform</groupId>
-                <artifactId>quarkus-camel-bom</artifactId>
-                <version>${quarkus-platform-version}</version>
+                <groupId>org.apache.camel.quarkus</groupId>
+                <artifactId>camel-quarkus-bom</artifactId>
+                <version>${camel-quarkus-version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
* The latter bom allows for the camel-quarkus dependencies to be correctly aligned by choosing the correct bom version based on the ${camel-quarkus-version}

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
