### PR TITLE
Use the non productized version of camel-openapi-rest-dsl-generator

### DIFF
--- a/support/camel-k-maven-plugin/pom.xml
+++ b/support/camel-k-maven-plugin/pom.xml
@@ -61,9 +61,12 @@
             <artifactId>camel-k-catalog-model</artifactId>
         </dependency>
         <dependency>
+            <!-- Do not use camel-version property, in this case PNC will align this
+                 artifact to a productized version.
+                Set the version number, with the same version defined in the root pom -->
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-openapi-rest-dsl-generator</artifactId>
-            <version>${camel-version}</version>
+            <version>3.18.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>


### PR DESCRIPTION
PNC build is failing because it is trying to use a productized version

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
