### PR TITLE
Fix quarkus-maven-plugin to use the quarkus-platform-version property

### DIFF
--- a/examples/cron/pom.xml
+++ b/examples/cron/pom.xml
@@ -66,7 +66,7 @@
             <plugin>
                 <groupId>${quarkus-platform-group}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus-version}</version>
+                <version>${quarkus-platform-version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/examples/groovy/pom.xml
+++ b/examples/groovy/pom.xml
@@ -58,7 +58,7 @@
             <plugin>
                 <groupId>${quarkus-platform-group}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus-version}</version>
+                <version>${quarkus-platform-version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/examples/java/pom.xml
+++ b/examples/java/pom.xml
@@ -58,7 +58,7 @@
             <plugin>
                 <groupId>${quarkus-platform-group}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus-version}</version>
+                <version>${quarkus-platform-version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/examples/js/pom.xml
+++ b/examples/js/pom.xml
@@ -58,7 +58,7 @@
             <plugin>
                 <groupId>${quarkus-platform-group}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus-version}</version>
+                <version>${quarkus-platform-version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/examples/kafka-source-s3/pom.xml
+++ b/examples/kafka-source-s3/pom.xml
@@ -58,7 +58,7 @@
             <plugin>
                 <groupId>${quarkus-platform-group}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus-version}</version>
+                <version>${quarkus-platform-version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/examples/kamelets-discovery/pom.xml
+++ b/examples/kamelets-discovery/pom.xml
@@ -61,7 +61,7 @@
             <plugin>
                 <groupId>${quarkus-platform-group}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus-version}</version>
+                <version>${quarkus-platform-version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/examples/kamelets/pom.xml
+++ b/examples/kamelets/pom.xml
@@ -61,7 +61,7 @@
             <plugin>
                 <groupId>${quarkus-platform-group}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus-version}</version>
+                <version>${quarkus-platform-version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/examples/knative/pom.xml
+++ b/examples/knative/pom.xml
@@ -65,7 +65,7 @@
             <plugin>
                 <groupId>${quarkus-platform-group}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus-version}</version>
+                <version>${quarkus-platform-version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/examples/kotlin/pom.xml
+++ b/examples/kotlin/pom.xml
@@ -57,7 +57,7 @@
             <plugin>
                 <groupId>${quarkus-platform-group}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus-version}</version>
+                <version>${quarkus-platform-version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/examples/xml/pom.xml
+++ b/examples/xml/pom.xml
@@ -57,7 +57,7 @@
             <plugin>
                 <groupId>${quarkus-platform-group}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus-version}</version>
+                <version>${quarkus-platform-version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/examples/yaml/pom.xml
+++ b/examples/yaml/pom.xml
@@ -61,7 +61,7 @@
             <plugin>
                 <groupId>${quarkus-platform-group}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus-version}</version>
+                <version>${quarkus-platform-version}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -156,7 +156,7 @@
                     <plugin>
                         <groupId>${quarkus-platform-group}</groupId>
                         <artifactId>quarkus-maven-plugin</artifactId>
-                        <version>${quarkus-version}</version>
+                        <version>${quarkus-platform-version}</version>
                         <executions>
                             <execution>
                                 <id>dev</id>

--- a/pom.xml
+++ b/pom.xml
@@ -293,7 +293,7 @@
                 <plugin>
                     <groupId>${quarkus-platform-group}</groupId>
                     <artifactId>quarkus-maven-plugin</artifactId>
-                    <version>${quarkus-version}</version>
+                    <version>${quarkus-platform-version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
If the `quarkus-maven-plugin` uses the `quarkus-version` property then in PNC build it replaces the `quarkus-version` property to use the `io.quarkus` group while the `quarkus-platform-version` is for the `io.quartkus.platform` group, which in PNC build is replaced by the productized `com.redhat.quarkus.platform` group whose version may diverge from `io.quarkus`. 
A bit complicated, because the quarkus productization creates a new `com.redhat` group.

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
