### PR TITLE
Update mandrel image to mandrel-23-rhel8:23.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <quarkus-version>3.2.11.Final</quarkus-version>
         <quarkus-platform-group>com.redhat.quarkus.platform</quarkus-platform-group>
         <quarkus-platform-version>3.2.11.Final</quarkus-platform-version>
-        <quarkus-native-builder-image>registry.redhat.io/quarkus/mandrel-21-rhel8:21.3</quarkus-native-builder-image>
+        <quarkus-native-builder-image>registry.redhat.io/quarkus/mandrel-23-rhel8:23.0</quarkus-native-builder-image>
 
         <!-- camel-k-runtime specific -->
         <groovy-version>3.0.19</groovy-version>


### PR DESCRIPTION
Based on JDK 17

[The current image is deprecated ](https://catalog.redhat.com/software/containers/quarkus/mandrel-21-rhel8/60fab204411f224f8bc3c246?architecture=amd64&image=643e6f4dd73b790b20a8ee16)

Per the documentation [Red Hat build of Quarkus Supported Configurations](https://access.redhat.com/articles/4966181)

This is the supported version: [mandrel-23-rhel8:23.0](https://catalog.redhat.com/software/containers/quarkus/mandrel-23-rhel8/64b179336f0c49b59926209c?architecture=amd64&image=65a6f2266db2ce921bb903b9&container-tabs=technical-information) 

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Update mandrel image to mandrel-23-rhel8:23.0
```
