### PR TITLE
add org.graalvm.js:js-language dependency since it's needed

### DIFF
--- a/itests/camel-k-itests-loader-js/pom.xml
+++ b/itests/camel-k-itests-loader-js/pom.xml
@@ -37,6 +37,12 @@
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-js-dsl</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.graalvm.js</groupId>
+                    <artifactId>js</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
@@ -65,6 +71,11 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.graalvm.js</groupId>
+            <artifactId>js-language</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,9 @@
 
         <maven-version>3.8.6</maven-version>
         <camel-version>4.4.1</camel-version>
+        <!-- TODO: graalvm.js dependency is set in CEQ 3.9, verify if this definition is required when upgrading quarkus platform
+             this version is set in quarkus-camel-bom -->
+        <graalvm-js-version>23.1.2</graalvm-js-version>
 
         <!-- quarkus -->
         <quarkus-version>3.8.4</quarkus-version>
@@ -499,6 +502,12 @@
                 <groupId>org.apache.camel.k</groupId>
                 <artifactId>camel-k-itests-runtime-inspector</artifactId>
                 <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.graalvm.js</groupId>
+                <artifactId>js-language</artifactId>
+                <scope>test</scope>
+                <version>${graalvm-js-version}</version>
             </dependency>
 
             <!-- support -->


### PR DESCRIPTION
for camel-quarkus-js-dsl, but camel and ceq diverge versions

quarkus platform downstream brings CEQ 3.8.0.redhat-00004 which doesn't contain the org.graalvm.js:js-language

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
