### PR TITLE
Update mandrel image to mandrel-for-jdk-21-rhel8:23.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <quarkus-version>3.8.4</quarkus-version>
         <quarkus-platform-group>com.redhat.quarkus.platform</quarkus-platform-group>
         <quarkus-platform-version>3.8.4</quarkus-platform-version>
-        <quarkus-native-builder-image>registry.redhat.io/quarkus/mandrel-21-rhel8:21.3</quarkus-native-builder-image>
+        <quarkus-native-builder-image>registry.redhat.io/quarkus/mandrel-for-jdk-21-rhel8:23.1</quarkus-native-builder-image>
 
         <!-- camel-k-runtime specific -->
         <groovy-version>4.0.20</groovy-version>


### PR DESCRIPTION
The previous image is deprecated.

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
